### PR TITLE
gitlint: Fix hostap upstream PR URL

### DIFF
--- a/gitlint/ncs.py
+++ b/gitlint/ncs.py
@@ -56,7 +56,7 @@ class NCSSauceTags(CommitRule):
         elif tag == 'fromlist':
             regex = r'^Upstream PR: (' \
                      'https://github\.com/.*/pull/\d+|' \
-                     'http://lists.infradead.org/pipermail/hostap/.*\.html' \
+                     'https://lists.infradead.org/pipermail/hostap/.*\.html' \
                      ')'
 
             matches = re.findall(regex, '\n'.join(commit.message.body), re.MULTILINE)


### PR DESCRIPTION
Allow HTTPS by default, copying the link from browser has HTTPS.